### PR TITLE
do not use dev.tekton to avoid colision with official

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ when it detects a change of state of each step.
 
 Supported CloudEvents event type are:
 ```
-dev.tekton.event.plugin.step.started.v1  
-dev.tekton.event.plugin.step.failed.v1
-dev.tekton.event.plugin.step.succeeded.v1
-dev.tekton.event.plugin.step.skipped.v1
+tom24d.event.plugin.step.started.v1  
+tom24d.event.plugin.step.failed.v1
+tom24d.event.plugin.step.succeeded.v1
+tom24d.event.plugin.step.skipped.v1
 ```
 
 When it detects the state for any emission, it gathers its corresponding defined information such as 
@@ -66,14 +66,11 @@ The example of CloudEvent is:
  Validation: valid
  Context Attributes,
    specversion: 1.0
-   type: dev.tekton.event.plugin.step.succeeded.v1
+   type: tom24d.event.plugin.step.succeeded.v1
    source: github.com/tom24d/step-observe-controller
-   id: 50df8d70-8c11-4cd4-8fdf-3aa4cb287408-unnamed-0-dev.tekton.event.plugin.step.succeeded.v1
+   id: 50df8d70-8c11-4cd4-8fdf-3aa4cb287408-unnamed-0-tom24d.event.plugin.step.succeeded.v1
    time: 2020-08-12T12:07:54Z
    datacontenttype: application/json
- Extensions,
-   knativearrivaltime: 2020-08-12T12:07:55.3392277Z
-   knativehistory: inmemorychannel-kne-trigger-kn-channel.test-event-assertion-success-fail-skip-skip-in-memory-chan7f5q7.svc.cluster.local
  Data,
    {
      "podRef": {

--- a/pkg/events/step/cloudevent.go
+++ b/pkg/events/step/cloudevent.go
@@ -23,10 +23,10 @@ const (
 type TektonPluginEventType string
 
 const (
-	CloudEventTypeStepStarted   TektonPluginEventType = "dev.tekton.event.plugin.step.started.v1"
-	CloudEventTypeStepFailed    TektonPluginEventType = "dev.tekton.event.plugin.step.failed.v1"
-	CloudEventTypeStepSucceeded TektonPluginEventType = "dev.tekton.event.plugin.step.succeeded.v1"
-	CloudEventTypeStepSkipped   TektonPluginEventType = "dev.tekton.event.plugin.step.skipped.v1"
+	CloudEventTypeStepStarted   TektonPluginEventType = "tom24d.event.plugin.step.started.v1"
+	CloudEventTypeStepFailed    TektonPluginEventType = "tom24d.event.plugin.step.failed.v1"
+	CloudEventTypeStepSucceeded TektonPluginEventType = "tom24d.event.plugin.step.succeeded.v1"
+	CloudEventTypeStepSkipped   TektonPluginEventType = "tom24d.event.plugin.step.skipped.v1"
 )
 
 func (c TektonPluginEventType) String() string {


### PR DESCRIPTION
This patch change CloudEvents type
from
```
dev.tekton.event.plugin....
```
to
```
tom24d.event.plugin....
```